### PR TITLE
Fix friendly/ unfriendly zone text for High Elfs/ Goblins

### DIFF
--- a/Libs/Tourist-2.0/Tourist-2.0.lua
+++ b/Libs/Tourist-2.0/Tourist-2.0.lua
@@ -23,7 +23,7 @@ local Z = AceLibrary("Babble-Zone-2.2")
 
 local playerLevel = 1
 local _,race = UnitRace("player")
-local isHorde = (race == "Orc" or race == "Troll" or race == "Tauren" or race == "Scourge" or race == "BloodElf")
+local isHorde = (race == "Orc" or race == "Troll" or race == "Tauren" or race == "Scourge" or race == "Goblin")
 local isWestern = GetLocale() == "enUS" or GetLocale() == "ruRU" or GetLocale() == "deDE" or GetLocale() == "frFR" or GetLocale() == "esES"
 local math_mod = math.fmod or math.mod
 


### PR DESCRIPTION
Summary:

- Replaces the "BloodElf" value with "Goblin" in the isHorde local variable.

Issues Addressed: 
- When playing as a High Elf character, Alliance Zones were incorrectly colored in red text (unfriendly), and Horde Zones were colored in green text (friendly).
- When playing as a Goblin character, Horde Zones were incorrectly colored in red text, and Alliance Zones were colored in green text.