### PR TITLE
Change WorldMapTooltip drawlayer to default value

### DIFF
--- a/Modules/LookNFeel.lua
+++ b/Modules/LookNFeel.lua
@@ -271,6 +271,7 @@ function Cartographer_LookNFeel:OnEnable()
 	Cartographer:AddToMagnifyingGlass(L["Ctrl-MouseWheel to change scale"])
 	UIPanelWindows["WorldMapFrame"] = nil
 	WorldMapFrame:SetFrameStrata("HIGH")
+	WorldMapTooltip:SetFrameStrata("TOOLTIP")
 	WorldMapFrame:EnableMouse(not self.db.profile.locked)
 	WorldMapFrame:EnableMouseWheel(not self.db.profile.locked)
 	WorldMapButton:EnableMouse(not self.db.profile.locked)


### PR DESCRIPTION
Changing the FrameStrata of WorldMapFrame also changes the strata of its child elements. This turns the WorldMapTooltip from `TOOLTIP` down to `HIGH` which places it below some elements of other addons.

The game default of the WorldMapTooltip is `TOOLTIP` and I don't see a reason why it should be set to only `HIGH` as it just breaks things.

By this commit, the FrameStrata of the WorldMapTooltip is set back to the game default value: `TOOLTIP`.

Fixes: https://github.com/shagu/pfQuest/issues/25